### PR TITLE
QoS Socket disconnect fix

### DIFF
--- a/SwiftMQTT/SwiftMQTT/MQTTSession.swift
+++ b/SwiftMQTT/SwiftMQTT/MQTTSession.swift
@@ -157,7 +157,9 @@ open class MQTTSession {
         case let pubAck as MQTTPubAck:
             callSuccessCompletionBlock(for: pubAck.messageID)
         case let publishPacket as MQTTPublishPacket:
-            sendPubAck(for: publishPacket.messageID)
+            if publishPacket.message.QoS != .atMostOnce {
+                sendPubAck(for: publishPacket.messageID)
+            }
             let message = MQTTMessage(publishPacket: publishPacket)
             delegateQueue.async { [weak self] in
                 self?.delegate?.mqttDidReceive(message: message, from: self!)


### PR DESCRIPTION
When a publish was received with QoS of 0 there was a publish Acknowledgment sent with a MessageID of 0 causing the server to send an endEncountered event closing the socket.